### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/i18n/id/code.json
+++ b/i18n/id/code.json
@@ -128,7 +128,7 @@
     "description": "the first and only requirement in the homepage requirement box"
   },
   "home.infoBox.requirement.content.description": {
-    "message": "[Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) and [Bedrock Edition](https://minecraft.fandom.com/wiki/Bedrock_Edition) are supported.",
+    "message": "[Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) and [Bedrock Edition](https://minecraft.wiki/w/Bedrock_Edition) are supported.",
     "description": "Extra foldout section of Minecraft in homepage describing we supports all version of it"
   },
   "home.infoBox.requirement.cracked-1": {

--- a/i18n/my/code.json
+++ b/i18n/my/code.json
@@ -128,7 +128,7 @@
     "description": "the first and only requirement in the homepage requirement box"
   },
   "home.infoBox.requirement.content.description": {
-    "message": "[Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) and [Bedrock Edition](https://minecraft.fandom.com/wiki/Bedrock_Edition) are supported.",
+    "message": "[Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) and [Bedrock Edition](https://minecraft.wiki/w/Bedrock_Edition) are supported.",
     "description": "Extra foldout section of Minecraft in homepage describing we supports all version of it"
   },
   "home.infoBox.requirement.cracked-1": {

--- a/i18n/ph/code.json
+++ b/i18n/ph/code.json
@@ -128,7 +128,7 @@
     "description": "the first and only requirement in the homepage requirement box"
   },
   "home.infoBox.requirement.content.description": {
-    "message": "[Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) and [Bedrock Edition](https://minecraft.fandom.com/wiki/Bedrock_Edition) are supported.",
+    "message": "[Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) and [Bedrock Edition](https://minecraft.wiki/w/Bedrock_Edition) are supported.",
     "description": "Extra foldout section of Minecraft in homepage describing we supports all version of it"
   },
   "home.infoBox.requirement.cracked-1": {

--- a/i18n/th/code.json
+++ b/i18n/th/code.json
@@ -56,7 +56,7 @@
     "description": "the first and only requirement in the homepage requirement box"
   },
   "home.infoBox.requirement.content.description": {
-    "message": "ทั้งสองรุ่น ของ Minecraft [Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) เเละ [Bedrock Edition](https://minecraft.fandom.com/wiki/Bedrock_Edition) สามารถเข้าได้",
+    "message": "ทั้งสองรุ่น ของ Minecraft [Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) เเละ [Bedrock Edition](https://minecraft.wiki/w/Bedrock_Edition) สามารถเข้าได้",
     "description": "Extra foldout section of Minecraft in homepage describing we supports all version of it"
   },
   "home.infoBox.requirement.cracked-1": {

--- a/i18n/vn/code.json
+++ b/i18n/vn/code.json
@@ -56,7 +56,7 @@
     "description": "the first and only requirement in the homepage requirement box"
   },
   "home.infoBox.requirement.content.description": {
-    "message": "Có hỗ trợ [Phiên bản Java](https://www.minecraft.net/en-us/store/minecraft-java-edition) và [Phiên bản Bedrock](https://minecraft.fandom.com/wiki/Bedrock_Edition).",
+    "message": "Có hỗ trợ [Phiên bản Java](https://www.minecraft.net/en-us/store/minecraft-java-edition) và [Phiên bản Bedrock](https://minecraft.wiki/w/Bedrock_Edition).",
     "description": "Extra foldout section of Minecraft in homepage describing we supports all version of it"
   },
   "home.infoBox.requirement.cracked-1": {

--- a/src/pages/home/_page/components/InfoBox/InfoBox.jsx
+++ b/src/pages/home/_page/components/InfoBox/InfoBox.jsx
@@ -50,7 +50,7 @@ const InfoBoxContents = {
                     <MarkdownBlock>
                     <Translate id="home.infoBox.requirement.content.description" description="Extra foldout section of Minecraft in homepage describing we supports all version of it">
                         [Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-edition) and 
-                        [Bedrock Edition](https://minecraft.fandom.com/wiki/Bedrock_Edition) are supported.
+                        [Bedrock Edition](https://minecraft.wiki/w/Bedrock_Edition) are supported.
                     </Translate>
                     </MarkdownBlock>
                 </span>


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki